### PR TITLE
Update max date of _localtime64_s()

### DIFF
--- a/docs/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s.md
+++ b/docs/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s.md
@@ -109,7 +109,7 @@ errno_t _localtime64_s(
 > [!NOTE]
 >  The target environment should try to determine whether daylight saving time is in effect.  
   
- `_localtime64_s`, which uses the `__time64_t` structure, allows dates to be expressed up through 23:59:59, December 31, 3000, coordinated universal time (UTC), whereas `_localtime32_s` represents dates through 23:59:59 January 18, 2038, UTC.  
+ `_localtime64_s`, which uses the `__time64_t` structure, allows dates to be expressed up through 23:59:59, January 18, 3001, coordinated universal time (UTC), whereas `_localtime32_s` represents dates through 23:59:59 January 18, 2038, UTC.  
   
  `localtime_s` is an inline function which evaluates to `_localtime64_s`, and `time_t` is equivalent to `__time64_t`. If you need to force the compiler to interpret `time_t` as the old 32-bit `time_t`, you can define `_USE_32BIT_TIME_T`. Doing this will cause `localtime_s` to evaluate to `_localtime32_s`. This is not recommended because your application may fail after January 18, 2038, and it is not allowed on 64-bit platforms.  
   


### PR DESCRIPTION
The max date used to be the last day of year 3000. 
It was recently changed to a few (18) days into 3001 to avoid issues with different timezone around the year change.