### PR TITLE
String::operator+ summary is incorrectly describing String::operator==

### DIFF
--- a/docs/cppcx/platform-string-class.md
+++ b/docs/cppcx/platform-string-class.md
@@ -301,7 +301,7 @@ int len = str->Length(); //len = 5
 
 
 ## <a name="operator-plus"></a>  String::operator+ Operator
-Indicates whether two specifed [String](../cppcx/platform-string-class.md) objects have the same value.  
+Concatenates two [String](../cppcx/platform-string-class.md) objects into a new [String](../cppcx/platform-string-class.md) object.
   
 ### Syntax  
   


### PR DESCRIPTION
Fix the summary for String::operator+.  It was incorrectly describing the String::operator==