### PR TITLE
Create ellipses-and-variadic-templates.md

### DIFF
--- a/docs/cpp/ellipses-and-variadic-templates.md
+++ b/docs/cpp/ellipses-and-variadic-templates.md
@@ -114,7 +114,7 @@ template <typename First, typename... Rest> returntype functionname(const First&
 template<typename... Arguments>  
 void tfunc(const Arguments&... args)  
 {  
-    const unsigned numargs = sizeof...(Arguments);  
+    constexpr auto numargs{ sizeof...(Arguments) };  
   
     X xobj[numargs]; // array of some previously defined type X  
   


### PR DESCRIPTION
I guess it's often making a difficult choice between making the code sample as simple as possible to convey the informative or taking the risk of using C++ features that make the example more obscure than it needs to be. :-)
However, there's also the risk of transmitting information that's copy/pasted again and again when there is a better way to write it in  "modern" C++ that all descent compilers support in 2017. That's why I believe:
1. constexpr should be used here instead of const.
2. The size in bytes of the type (size_t) will be different on x86 and x64 so auto (or size_t) would be recommended.
3. Using uniform initialization as it doesn't allow you to implicitly narrow a type into another type: useful here if you'd have compiled under x64 and assigned to an unsigned (32-bit) type.